### PR TITLE
Update uc_cart.info.inc to fix Cart quantity update issue

### DIFF
--- a/uc_cart/uc_cart.info.inc
+++ b/uc_cart/uc_cart.info.inc
@@ -36,7 +36,7 @@ function uc_cart_entity_property_info() {
     'type' => 'integer',
     'label' => t('Quantity'),
     'description' => t('The number of this product in the cart.'),
-    'setter callback' => 'entity_property_verbatim_set',
+    'setter callback' => 'entity_plus_property_verbatim_set',
     'schema field' => 'qty',
   );
   $properties['changed'] = array(


### PR DESCRIPTION
Fixes error caused when cart product quantity update is a higher value than set in Rules.