### PR TITLE
Apply Drupal patch to create rules for handling admin stock changes.

### DIFF
--- a/uc_order/uc_order.admin.inc
+++ b/uc_order/uc_order.admin.inc
@@ -1103,11 +1103,9 @@ function uc_order_edit_form_submit($form, &$form_state) {
     }
   }
 
-  if (module_exists('uc_stock')) {
-    $qtys = array();
-    foreach ($order->products as $product) {
-      $qtys[$product->order_product_id] = $product->qty;
-    }
+  $qtys = array();
+  foreach ($order->products as $product) {
+    $qtys[$product->order_product_id] = $product->qty;
   }
 
   $order->products = array();
@@ -1118,12 +1116,10 @@ function uc_order_edit_form_submit($form, &$form_state) {
         $product = (object) $product;
         $order->products[] = $product;
 
-        if (module_exists('uc_stock')) {
-          $temp = $product->qty;
-          $product->qty = $product->qty - $qtys[$product->order_product_id];
-          uc_stock_adjust_product_stock($product, 0, $order);
-          $product->qty = $temp;
-        }
+        $restore_qty = $product->qty;
+        $product->qty = $product->qty - $qtys[$product->order_product_id];
+        rules_invoke_event('uc_order_product_updated', $order, $product);
+        $product->qty = $restore_qty;
       }
       else {
         $log['remove_' . $product['nid']] = $product['title'] . ' removed from order.';

--- a/uc_order/uc_order.order_pane.inc
+++ b/uc_order/uc_order.order_pane.inc
@@ -571,10 +571,7 @@ function uc_order_edit_products_add($form, &$form_state) {
 
   uc_order_log_changes($order->order_id, array('add' => t('Added (@qty) @title to order.', array('@qty' => $product->qty, '@title' => $product->title))));
 
-  // Decrement stock.
-  if (module_exists('uc_stock')) {
-    uc_stock_adjust_product_stock($product, 0, $order);
-  }
+  rules_invoke_event('uc_order_product_updated', $order, $product);
 
   // Add this product to the form values for accurate tax calculations.
   $form_state['values']['products'][] = (array) $product;
@@ -587,22 +584,15 @@ function uc_order_edit_products_remove($form, &$form_state) {
   $form_state['refresh_products'] = TRUE;
 
   $order_product_id = intval($form_state['triggering_element']['#return_value']);
+  $order = $form_state['build_info']['args'][0];
+  $product = db_query("SELECT model, qty, title FROM {uc_order_products} WHERE order_product_id = :id", array(':id' => $order_product_id))->fetchObject();
+  $product->qty = -($product->qty);
 
-  if (module_exists('uc_stock')) {
-    // Replace stock immediately.
-    $product = uc_order_product_load($order_product_id);
-    uc_stock_adjust($product->model, $product->qty);
-  }
+  uc_order_log_changes($order->order_id, array('add' => t('Removed (@qty) @title from order.', array('@qty' => $product->qty, '@title' => $product->title))));
+
+  rules_invoke_event('uc_order_product_updated', $order, $product);
 
   uc_order_product_delete($order_product_id);
-
-  $order = $form_state['build_info']['args'][0];
-  $matches = array();
-  preg_match('/products\[(\d+)\]/', $form_state['triggering_element']['#name'], $matches);
-  $key = $matches[1];
-
-  unset($order->products[$key]);
-  $order->products = array_values($order->products);
 }
 
 /**

--- a/uc_order/uc_order.rules.inc
+++ b/uc_order/uc_order.rules.inc
@@ -35,6 +35,21 @@ function uc_order_rules_data_info() {
  * Implements hook_rules_event_info().
  */
 function uc_order_rules_event_info() {
+  $events['uc_order_product_updated'] = array(
+    'label' => t('A product within an order changes qty'),
+    'group' => t('Order'),
+    'variables' => array(
+      'order' => array(
+        'type' => 'uc_order',
+        'label' => t('Original order'),
+      ),
+      'product' => array(
+        'type' => 'uc_order_product',
+        'label' => t('Updated product with change in qty'),
+      ),
+    ),
+  );
+
   $events['uc_order_status_update'] = array(
     'label' => t('Order status gets updated'),
     'group' => t('Order'),

--- a/uc_stock/uc_stock.rules.inc
+++ b/uc_stock/uc_stock.rules.inc
@@ -9,8 +9,24 @@
  * Implements hook_rules_action_info().
  */
 function uc_stock_rules_action_info() {
+  $actions['uc_stock_action_adjust_product_stock'] = array(
+    'label' => t('Adjust stock of a product with tracking activated.'),
+    'group' => t('Stock'),
+    'base' => 'uc_stock_action_adjust_product_stock',
+    'parameter' => array(
+      'order' => array(
+        'type' => 'uc_order',
+        'label' => t('Order'),
+      ),
+      'product' => array(
+        'type' => 'uc_order_product',
+        'label' => t('Product'),
+      ),
+    ),
+  );
+
   $actions['uc_stock_action_decrement_stock'] = array(
-    'label' => t('Decrement stock of products on the order with tracking activated.'),
+    'label' => t('Decrement stock of products with tracking activated on the order.'),
     'group' => t('Stock'),
     'base' => 'uc_stock_action_decrement_stock',
     'parameter' => array(
@@ -22,7 +38,7 @@ function uc_stock_rules_action_info() {
   );
 
   $actions['uc_stock_action_increment_stock'] = array(
-    'label' => t('Increment stock of products on the order with tracking activated.'),
+    'label' => t('Increment stock of products with tracking activated on the order.'),
     'group' => t('Stock'),
     'base' => 'uc_stock_action_increment_stock',
     'parameter' => array(
@@ -37,7 +53,14 @@ function uc_stock_rules_action_info() {
 }
 
 /**
- * Decreases the stock of ordered products.
+ * Decrease the stock of a product by the amount in $product->qty.
+ */
+function uc_stock_action_adjust_product_stock($order, $product) {
+  uc_stock_adjust_product_stock($product, 0, $order);
+}
+
+/**
+ * Decrease the stock of ordered products.
  */
 function uc_stock_action_decrement_stock($order) {
   if (is_array($order->products)) {

--- a/uc_stock/uc_stock.rules_defaults.inc
+++ b/uc_stock/uc_stock.rules_defaults.inc
@@ -12,7 +12,16 @@ function uc_stock_default_rules_configuration() {
   $configs = array();
 
   $rule = rules_reaction_rule();
-  $rule->label = t('Decrement stock upon order submission');
+  $rule->label = t('Adjust stock upon change of product in order');
+  $rule->tags = array('uc_stock');
+  $rule->active = TRUE;
+  $rule->event('uc_order_product_updated')
+    ->action('uc_stock_action_adjust_product_stock', array('order:select' => 'order', 'product:select' => 'product'));
+  $configs['uc_stock_adjust_on_product_change'] = $rule;
+
+  $rule = rules_reaction_rule();
+  $rule->label = t('Decrement stock upon order completion');
+  $rule->tags = array('uc_stock');
   $rule->active = TRUE;
   $rule->event('uc_checkout_complete')
     ->action('uc_stock_action_decrement_stock', array('order:select' => 'order'));
@@ -20,6 +29,7 @@ function uc_stock_default_rules_configuration() {
 
   $rule = rules_reaction_rule();
   $rule->label = t('Increment stock on cancelling order');
+  $rule->tags = array('uc_stock');
   $rule->active = FALSE;
   $rule->event('uc_order_status_update')
     ->condition(rules_condition('data_is', array('data:select' => 'updated_order:order-status', 'value' => 'canceled')))
@@ -30,6 +40,7 @@ function uc_stock_default_rules_configuration() {
 
   $rule = rules_reaction_rule();
   $rule->label = t('Increment stock on deleting an order');
+  $rule->tags = array('uc_stock');
   $rule->active = FALSE;
   $rule->event('uc_order_delete')
     ->condition(rules_condition('data_is', array('data:select' => 'order:order-status', 'value' => 'canceled'))->negate())
@@ -39,6 +50,7 @@ function uc_stock_default_rules_configuration() {
 
   $rule = rules_reaction_rule();
   $rule->label = t('Decrement stock when order cancellation is being undone');
+  $rule->tags = array('uc_stock');
   $rule->active = FALSE;
   $rule->event('uc_order_status_update')
     ->condition(rules_condition('data_is', array('data:select' => 'order:order-status', 'value' => 'canceled')))


### PR DESCRIPTION
Added a new event, 'uc_order_product_updated', to uc_order, which fires on product changes in admin edited orders;
Added a new action, 'uc_stock_action_adjust_product_stock', to uc_stock, which updates stock levels based on changes in individual products;
Added a new default rule, 'uc_stock_adjust_on_product_change', to uc_stock, which connects the two.
Throughout uc_order and uc_stock, removed the direct stock manipulations that happened for edited orders and replaced them with firings of the 'uc_order_product_updated' event.
Gave all uc_stock-related rules the tag 'uc_stock' so that tag filtering in Rules is useful.