### PR TITLE
Issue 258: add Rules events for Paypal actions

### DIFF
--- a/payment/uc_paypal/uc_paypal.info
+++ b/payment/uc_paypal/uc_paypal.info
@@ -1,6 +1,7 @@
 name = PayPal
 description = Processes payments using PayPal Website Payments Standard, Website Payments Pro and Express Checkout.
 dependencies[] = uc_payment
+dependencies[] = rules
 package = Ubercart - payment
 backdrop = 1.x
 type = module

--- a/payment/uc_paypal/uc_paypal.install
+++ b/payment/uc_paypal/uc_paypal.install
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Install, update and uninstall functions for the uc_paypal module.

--- a/payment/uc_paypal/uc_paypal.pages.inc
+++ b/payment/uc_paypal/uc_paypal.pages.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Paypal administration menu items.
@@ -114,6 +113,7 @@ function uc_paypal_ipn() {
     switch ($payment_status) {
       case 'Canceled_Reversal':
         uc_order_comment_save($order_id, 0, t('PayPal has canceled the reversal and returned !amount !currency to your account.', array('!amount' => uc_currency_format($payment_amount, FALSE), '!currency' => $payment_currency)), 'admin');
+        rules_invoke_event('uc_paypal_event_cancelled_reversal', $order);
         break;
 
       case 'Completed':
@@ -124,48 +124,58 @@ function uc_paypal_ipn() {
         uc_payment_enter($order_id, 'paypal_wps', $payment_amount, $order->uid, NULL, $comment);
         uc_cart_complete_sale($order);
         uc_order_comment_save($order_id, 0, t('PayPal IPN reported a payment of @amount @currency.', array('@amount' => uc_currency_format($payment_amount, FALSE), '@currency' => $payment_currency)));
+        rules_invoke_event('uc_paypal_event_completed', $order);
         break;
 
       case 'Denied':
         uc_order_comment_save($order_id, 0, t("You have denied the customer's payment."), 'admin');
+        rules_invoke_event('uc_paypal_event_denied', $order);
         break;
 
       case 'Expired':
         uc_order_comment_save($order_id, 0, t('The authorization has failed and cannot be captured.'), 'admin');
+        rules_invoke_event('uc_paypal_event_expired', $order);
         break;
 
       case 'Failed':
         uc_order_comment_save($order_id, 0, t("The customer's attempted payment from a bank account failed."), 'admin');
+        rules_invoke_event('uc_paypal_event_failed', $order);
         break;
 
       case 'Pending':
         uc_order_update_status($order_id, 'paypal_pending');
         uc_order_comment_save($order_id, 0, t('Payment is pending at PayPal: @reason', array('@reason' => _uc_paypal_pending_message(check_plain($_POST['pending_reason'])))), 'admin');
+        rules_invoke_event('uc_paypal_event_pending', $order);
         break;
 
       // You, the merchant, refunded the payment.
       case 'Refunded':
         $comment = t('PayPal transaction ID: @txn_id', array('@txn_id' => $txn_id));
         uc_payment_enter($order_id, 'paypal_wps', $payment_amount, $order->uid, NULL, $comment);
+        rules_invoke_event('uc_paypal_event_refunded', $order);
         break;
 
       case 'Reversed':
         watchdog('uc_paypal', 'PayPal has reversed a payment!', array(), WATCHDOG_ERROR);
         uc_order_comment_save($order_id, 0, t('Payment has been reversed by PayPal: @reason', array('@reason' => _uc_paypal_reversal_message(check_plain($_POST['reason_code'])))), 'admin');
+        rules_invoke_event('uc_paypal_event_reversed', $order);
         break;
 
       case 'Processed':
         uc_order_comment_save($order_id, 0, t('A payment has been accepted.'), 'admin');
+        rules_invoke_event('uc_paypal_event_processed', $order);
         break;
 
       case 'Voided':
         uc_order_comment_save($order_id, 0, t('The authorization has been voided.'), 'admin');
+        rules_invoke_event('uc_paypal_event_voided', $order);
         break;
     }
   }
   elseif (strcmp($response->data, 'INVALID') == 0) {
     watchdog('uc_paypal', 'IPN transaction failed verification.', array(), WATCHDOG_ERROR);
     uc_order_comment_save($order_id, 0, t('An IPN transaction failed verification for this order.'), 'admin');
+    rules_invoke_event('uc_paypal_event_verification_fail', $order);
   }
 }
 

--- a/payment/uc_paypal/uc_paypal.rules.inc
+++ b/payment/uc_paypal/uc_paypal.rules.inc
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @file
+ * Rules hooks for uc_paypal.module.
+ */
+
+/**
+ * Implements hook_rules_event_info().
+ */
+function uc_paypal_rules_event_info() {
+  $events = array(
+    'uc_paypal_event_cancelled_reversal' => array(
+      'label' => t('Paypal cancelled payment reversal'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_completed' => array(
+      'label' => t('Paypal completed payment'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_denied' => array(
+      'label' => t('Paypal denied payment'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_expired' => array(
+      'label' => t('Paypal authorization expired'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_failed' => array(
+      'label' => t('Paypal attempt failed'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_pending' => array(
+      'label' => t('Paypal payment is pending'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_refunded' => array(
+      'label' => t('Paypal payment refunded'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_reversed' => array(
+      'label' => t('Paypal reversed a payment'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_processed' => array(
+      'label' => t('Paypal accepted a payment'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_voided' => array(
+      'label' => t('Paypal authorization was voided'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+    'uc_paypal_event_verification_fail' => array(
+      'label' => t('Paypal IPN transaction failed'),
+      'group' => t('PayPal'),
+      'variables' => array(
+        'order' => array(
+          'type' => 'uc_order',
+          'label' => t('Order'),
+        ),
+      ),
+    ),
+  );
+  return $events;
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/258.

This PR adds Rules events for various PayPal actions. Store managers can use these events to trigger Rules actions like notification if a payment is declined or reversed.