### PR TITLE
Issue 261: Stock not updated when SKU changes

### DIFF
--- a/uc_stock/tests/uc_stock.test
+++ b/uc_stock/tests/uc_stock.test
@@ -71,7 +71,10 @@ class UbercartStockTestCase extends UbercartTestHelper {
   }
 
   public function testStockThresholdMail() {
-    $edit = array('uc_stock_threshold_notification' => 1);
+    $edit = array(
+      'uc_stock_threshold_notification' => 1,
+      'uc_stock_threshold_notification_recipients' => 'manager@mystore.com',
+    );
     $this->backdropPost('admin/store/settings/stock', $edit, 'Save configuration');
 
     $qty = rand(10, 100);
@@ -81,8 +84,13 @@ class UbercartStockTestCase extends UbercartTestHelper {
       'stock[0][threshold]' => $qty,
     );
     $this->backdropPost('node/' . $this->product->nid . '/edit/stock', $edit, 'Save changes');
-
     $this->backdropPost('node/' . $this->product->nid, array(), 'Add to cart');
+
+    // In order for Simpletest to grab the email to check its contents, we have
+    // to set the mail system to the TestingMailSystem instead of
+    // UbercartMailSystem.
+    config_set('system.mail', 'uc_stock', 'TestingMailSystem');
+
     $this->checkout();
 
     $mail = $this->backdropGetMails(array('id' => 'uc_stock_threshold'));
@@ -91,6 +99,39 @@ class UbercartStockTestCase extends UbercartTestHelper {
     $this->assertTrue(strpos($mail['body'], $this->product->title) !== FALSE, 'Mail body contains product title.');
     $this->assertTrue(strpos($mail['body'], $this->product->model) !== FALSE, 'Mail body contains SKU.');
     $this->assertTrue(strpos($mail['body'], 'has reached ' . $qty) !== FALSE, 'Mail body contains quantity.');
+  }
+
+  public function testStockConsistency() {
+    $this->backdropGet('node/' . $this->product->nid . '/edit/stock');
+    $this->assertText($this->product->title);
+    $this->assertText($this->product->model, 'Product SKU found.');
+
+    $this->assertNoFieldChecked('edit-stock-0-active', 'Stock tracking is not active.');
+    $this->assertFieldByName('stock[0][stock]', '0', 'Default stock level found.');
+    $this->assertFieldByName('stock[0][threshold]', '0', 'Default stock threshold found.');
+
+    $stock = 10;
+    $edit = array(
+      'stock[0][active]' => 1,
+      'stock[0][stock]' => $stock,
+      'stock[0][threshold]' => 3,
+    );
+    $this->backdropPost(NULL, $edit, t('Save changes'));
+
+    // now change sku
+    $this->backdropGet('node/' . $this->product->nid.'/edit');
+    $edit = array('model' => $this->product->model . 't');
+    $this->backdropPost(NULL, $edit, t('Save'));
+
+    // check stock for old and new sku
+    $this->assertNotEqual($stock, uc_stock_level($this->product->model));
+    $this->assertEqual($stock, uc_stock_level($this->product->model . 't'));
+
+    // also check in form
+    $this->backdropGet('node/' . $this->product->nid . '/edit/stock');
+    $this->assertFieldChecked('edit-stock-0-active', 'Stock tracking is active.');
+    $this->assertFieldByName('stock[0][stock]', $stock, 'Stock level maintained');
+    $this->assertFieldByName('stock[0][threshold]', 3, 'Setted stock threshold found.');
   }
 
 }

--- a/uc_stock/uc_stock.module
+++ b/uc_stock/uc_stock.module
@@ -114,6 +114,73 @@ function uc_stock_uc_message() {
 }
 
 /**
+ * Implements hook_entity_delete().
+ *
+ * Clean stock table when node has been deleted.
+ */
+function uc_stock_entity_delete($entity, $type) {
+  if ($type == 'node' && in_array($entity->type, uc_product_types())) {
+    db_delete('uc_product_stock')
+      ->condition('nid', $entity->nid)
+      ->execute();
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function uc_stock_entity_update($entity, $type) {
+  if ($type == 'node' && in_array($entity->type, uc_product_types())) {
+    $old_model = $entity->original->model;
+    $new_model = $entity->model;
+    if($old_model != $new_model) {
+      db_update('uc_product_stock')
+        ->fields(array('sku' => $new_model))
+        ->condition('sku', $old_model)
+        ->execute();
+      backdrop_set_message(t('Stock table updated: changed SKU @old_model to @new_model.', array('%title' => $entity->title, '@old_model' => $old_model, '@new_model' => $new_model)));
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for uc_product_adjustments_form().
+ *
+ * Save a copy of the original form values and insert our own submission
+ * function for product adjustments so we can update stock when model is changed
+ * for an attribute.
+ */
+function uc_stock_form_uc_product_adjustments_form_alter(&$form, &$form_state, $form_id) {
+  $form['original_body'] = array(
+    '#type' => 'value',
+    '#value' => $form['table']['body'],
+  );
+  $form['#submit'][] = 'uc_stock_form_uc_product_adjustments_form_submit';
+}
+
+/**
+ * Submission function for uc_product_adjustments_form().
+ *
+ * Update the stock table if the model number has changed for the variant.
+ *
+ * @see uc_product_adjustments_form_submit()
+ */
+function uc_stock_form_uc_product_adjustments_form_submit($form, &$form_state) {
+  foreach ($form_state['values']['body'] as $key => $value) {
+    $default_model = $form_state['values']['default'];
+    $old_model = !empty($form_state['values']['original_body'][$key]['model']) ? $form_state['values']['original_body'][$key]['model']['#default_value'] : '';
+    $new_model = !empty($value['model']) ? $value['model'] : '';
+    if ($old_model != $new_model) {
+      db_update('uc_product_stock')
+        ->fields(array('sku' => $new_model))
+        ->condition('sku', $old_model)
+        ->execute();
+      backdrop_set_message(t('Stock table updated: changed sku @old_model to @new_model', array('@old_model' => $old_model, '@new_model' => $new_model)));
+    }
+  }
+}
+
+/**
  * Adjusts the product stock level by a set amount.
  *
  * @param $sku


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/261.

Update the stock table when the SKU changes for either a product or a product adjustment. Also fix the uc_stock tests, which should now all pass. (There will still be a warning from uc-order--customer.tpl.php, which will get fixed in a separate PR related to fixing tests.)