### PR TITLE
Issue 265: PayPal titles long and/or erroneous on checkout page

### DIFF
--- a/payment/uc_paypal/uc_paypal.api.php
+++ b/payment/uc_paypal/uc_paypal.api.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @file
+ * Describe hooks provided by the Ubercart PayPal module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Allows alteration of the titles displayed with the PayPal payment method on
+ * the checkout page in the payment methods pane.
+ *
+ * @param string $title_wps
+ *   The title to use for Website Payments Standard.
+ * @param string $title_ec
+ *   The title to use for Express Checkout.
+ */
+function hook_uc_paypal_titles_alter(&$title_wps, &$title_ec) {
+  $title_wps = t('PayPal WPS');
+  $title_ec = t('PayPal EC');
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/payment/uc_paypal/uc_paypal.module
+++ b/payment/uc_paypal/uc_paypal.module
@@ -127,10 +127,14 @@ function uc_paypal_uc_payment_method() {
   }
   $title2 .= ' <img src="https://www.paypal.com/en_US/i/logo/PayPal_mark_37x23.gif" alt="PayPal" class="uc-credit-cctype" /></span>';
 
+  $title_wps = $title1 . $title2;
+  $title_ec = $title1;
+  backdrop_alter('uc_paypal_titles', $title_wps, $title_ec);
+
   $methods[] = array(
     'id' => 'paypal_wps',
     'name' => t('PayPal Website Payments Standard'),
-    'title' => $title1 . $title2,
+    'title' => $title_wps,
     'review' => t('PayPal'),
     'desc' => t('Redirect users to submit payments through PayPal.'),
     'callback' => 'uc_payment_method_paypal_wps',
@@ -143,7 +147,7 @@ function uc_paypal_uc_payment_method() {
   $methods[] = array(
     'id' => 'paypal_ec',
     'name' => t('PayPal Express Checkout'),
-    'title' => $title1,
+    'title' => $title_ec,
     'review' => t('PayPal'),
     'desc' => t('Complete orders through PayPal Express Checkout.'),
     'callback' => 'uc_payment_method_paypal_ec',


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/265.

Adds a hook to allow implementer override of the title text used on the checkout pane.