### PR TITLE
Issue 242: Image styles mixed up

### DIFF
--- a/uc_product/config/image.style.uc_product.json
+++ b/uc_product/config/image.style.uc_product.json
@@ -6,13 +6,13 @@
     "module": "uc_product",
     "effects": {
         "1": {
-          "name": "image_scale",
-          "data": {
-              "width": "",
-              "height": "",
-              "upscale": 0
-          },
-          "weight": 1
+            "name": "image_scale",
+            "data": {
+                "width": "250",
+                "height": "250",
+                "upscale": 0
+            },
+            "weight": 1
         }
     }
 }

--- a/uc_product/config/image.style.uc_product_full.json
+++ b/uc_product/config/image.style.uc_product_full.json
@@ -4,15 +4,5 @@
     "name": "uc_product_full",
     "storage": 4,
     "module": "uc_product",
-    "effects": {
-        "1": {
-          "name": "image_scale",
-          "data": {
-              "width": "250",
-              "height": "250",
-              "upscale": 0
-          },
-          "weight": 1
-        }
-    }
+    "effects": []
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/242.

Unswap the default image styles for ‘uc_product’ and ‘uc_product_full’.