### PR TITLE
Issue 280: Replace 'user_profile_item', 'user_profile_category' form items

### DIFF
--- a/uc_file/uc_file.module
+++ b/uc_file/uc_file.module
@@ -391,7 +391,7 @@ function uc_file_user_view($account, $view_mode) {
   }
 
   $item = array(
-    '#type' => 'user_profile_item',
+    '#type' => 'item',
     '#title' => t('File downloads'),
     '#markup' => l(t('Click here to view your file downloads.'), 'user/' . $account->uid . '/purchased-files'),
   );

--- a/uc_order/uc_order.module
+++ b/uc_order/uc_order.module
@@ -530,7 +530,7 @@ function uc_order_user_view($account, $view_mode) {
 
   if ($user->uid && (($user->uid == $account->uid && user_access('view own orders')) || user_access('view all orders'))) {
     $account->content['summary']['orders'] = array(
-      '#type' => 'user_profile_item',
+      '#type' => 'item',
       '#title' => t('Orders'),
       '#markup' => l(t('Click here to view your order history.'), 'user/' . $account->uid . '/orders'),
     );

--- a/uc_roles/uc_roles.module
+++ b/uc_roles/uc_roles.module
@@ -358,7 +358,7 @@ function uc_roles_user_view($account, $view_mode) {
   $expirations = db_query("SELECT * FROM {uc_roles_expirations} WHERE uid = :uid", array(':uid' => $account->uid));
   foreach ($expirations as $expiration) {
     $form[$expiration->role] = array(
-      '#type' => 'user_profile_item',
+      '#type' => 'item',
       '#title' => check_plain(_uc_roles_get_name($expiration->role)),
       '#markup' => t('This role will expire on !date', array('!date' => format_date($expiration->expiration, 'short'))),
     );
@@ -370,7 +370,7 @@ function uc_roles_user_view($account, $view_mode) {
   }
 
   $item = array(
-    '#type' => 'user_profile_category',
+    '#type' => 'item',
     '#weight' => '-1',
     '#title' => t('Expiring roles'),
   );


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/280.

Change the no-longer-supported FAPI types to `item`, which is supported and will display properly.