### PR TITLE
Issue 297: Replace "click here"

### DIFF
--- a/payment/uc_paypal/uc_paypal.module
+++ b/payment/uc_paypal/uc_paypal.module
@@ -550,7 +550,7 @@ function uc_payment_method_paypal_ec($op, &$order) {
       $form['api'] = array(
         '#type' => 'fieldset',
         '#title' => t('API credentials'),
-        '#description' => t('!link for information on obtaining credentials.  You need to acquire an API Signature.  If you have already requested API credentials, you can review your settings under the API Access section of your PayPal profile.', array('!link' => l(t('Click here'), 'https://developer.paypal.com/docs/classic/api/apiCredentials/'))),
+        '#description' => t('You need to acquire an API Signature.  If you have already requested API credentials, you can review your settings under the API Access section of your PayPal profile. !link', array('!link' => l(t('See information on obtaining credentials.'), 'https://developer.paypal.com/docs/classic/api/apiCredentials/'))),
         '#collapsible' => TRUE,
         '#collapsed' => $config->get('uc_paypal_api_username') != '',
       );

--- a/uc_cart/uc_cart_checkout_pane.inc
+++ b/uc_cart/uc_cart_checkout_pane.inc
@@ -53,7 +53,7 @@ function uc_checkout_pane_customer($op, $order, $form = NULL, &$form_state = NUL
       }
       else {
         $email = $order->primary_email;
-        $description = t('Enter a valid email address for this order or <a href="!url">click here</a> to login with an existing account and return to checkout.', array('!url' => url('user/login', array('query' => backdrop_get_destination()))));
+        $description = t('Enter a valid email address for this order or <a href="!url">login with an existing account and return to checkout</a>.', array('!url' => url('user/login', array('query' => backdrop_get_destination()))));
         $contents['primary_email'] = uc_textfield(t('E-mail address'), $email, TRUE, NULL, 64);
       }
 

--- a/uc_catalog/uc_catalog.module
+++ b/uc_catalog/uc_catalog.module
@@ -343,7 +343,7 @@ function uc_catalog_uc_store_status() {
     return array(array(
       'status' => 'error',
       'title' => t('Catalog field'),
-      'desc' => t('The catalog taxonomy reference field is missing. <a href="!url">Click here to create it</a>.', array('!url' => url('admin/store/settings/catalog/repair'))),
+      'desc' => t('The catalog taxonomy reference field is missing. <a href="!url">Create it.</a>', array('!url' => url('admin/store/settings/catalog/repair'))),
     ),
     );
   }

--- a/uc_file/uc_file.module
+++ b/uc_file/uc_file.module
@@ -393,7 +393,7 @@ function uc_file_user_view($account, $view_mode) {
   $item = array(
     '#type' => 'user_profile_item',
     '#title' => t('File downloads'),
-    '#markup' => l(t('Click here to view your file downloads.'), 'user/' . $account->uid . '/purchased-files'),
+    '#markup' => l(t('View your file downloads.'), 'user/' . $account->uid . '/purchased-files'),
   );
 
   $account->content['summary']['uc_file_download'] = $item;

--- a/uc_order/uc_order.api.php
+++ b/uc_order/uc_order.api.php
@@ -264,7 +264,7 @@ function hook_uc_order_actions_alter(&$actions, $order) {
  * The real meat of an order pane is its callback function (which is specified
  * in the hook). The callback function handles what gets displayed on which
  * screen and what data can be manipulated. That is all somewhat out of the
- * scope of this API page, so you'll have to click here to read more about what
+ * scope of this API page, so you'll have to read the Wiki for more about what
  * a callback function should contain.
  *
  * @return

--- a/uc_order/uc_order.module
+++ b/uc_order/uc_order.module
@@ -532,7 +532,7 @@ function uc_order_user_view($account, $view_mode) {
     $account->content['summary']['orders'] = array(
       '#type' => 'user_profile_item',
       '#title' => t('Orders'),
-      '#markup' => l(t('Click here to view your order history.'), 'user/' . $account->uid . '/orders'),
+      '#markup' => l(t('View your order history.'), 'user/' . $account->uid . '/orders'),
     );
   }
 }

--- a/uc_product/uc_product.module
+++ b/uc_product/uc_product.module
@@ -1073,7 +1073,7 @@ function uc_product_uc_store_status() {
   }
   else {
     $status = 'warning';
-    $description = t('<a href="!url">Click here</a> to automatically configure the following items for core image support:', array('!url' => url('admin/store/settings/products/defaults')));
+    $description = t('<a href="!url">Automatically configure the following items for core image support</a>:', array('!url' => url('admin/store/settings/products/defaults')));
 
     $items[] = t('The Image file field has not been created for products.');
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/279.

Replace "click here" language in several places in the UI and docs.