### PR TITLE
Issue #302. Avoid sending UcCartItem object array to uc_order_product_view_multiple

### DIFF
--- a/uc_cart/uc_cart_checkout_pane.inc
+++ b/uc_cart/uc_cart_checkout_pane.inc
@@ -524,9 +524,9 @@ function theme_uc_cart_review_table($variables) {
 
   // Set up table rows.
   // The following three lines transform the passed items
-  // into vanilla stdClass objects. This is done to avoid 
+  // into vanilla stdClass objects. This is done to avoid
   // passing the wrong entity types to uc_order_product_view_multiple.
-  // @see https://github.com/backdrop-contrib/ubercart/issues/302  
+  // @see https://github.com/backdrop-contrib/ubercart/issues/302
   $temp_products = array();
   foreach ($items as $id => $item) {
     $temp_products[$id] = (object) (array) $item;

--- a/uc_cart/uc_cart_checkout_pane.inc
+++ b/uc_cart/uc_cart_checkout_pane.inc
@@ -523,14 +523,15 @@ function theme_uc_cart_review_table($variables) {
   );
 
   // Set up table rows.
-  // The following three lines load the full order with the 
-  // UcOrderProduct array needed for correctly generating 
-  // a render array with uc_order_product_view_multiple.
+  // The following three lines transform the passed items
+  // into vanilla stdClass objects. This is done to avoid 
+  // passing the wrong entity types to uc_order_product_view_multiple.
   // @see https://github.com/backdrop-contrib/ubercart/issues/302  
-  $item = reset($items);
-  $order = uc_order_load($item->order_id);
-  $products = $order->products;
-  $display_items = uc_order_product_view_multiple($products);
+  $temp_products = array();
+  foreach ($items as $id => $item) {
+    $temp_products[$id] = (object) (array) $item;
+  }
+  $display_items = uc_order_product_view_multiple($temp_products);
   if (!empty($display_items['uc_order_product'])) {
     foreach (element_children($display_items['uc_order_product']) as $key) {
       $display_item = $display_items['uc_order_product'][$key];

--- a/uc_cart/uc_cart_checkout_pane.inc
+++ b/uc_cart/uc_cart_checkout_pane.inc
@@ -523,7 +523,14 @@ function theme_uc_cart_review_table($variables) {
   );
 
   // Set up table rows.
-  $display_items = uc_order_product_view_multiple($items);
+  // The following three lines load the full order with the 
+  // UcOrderProduct array needed for correctly generating 
+  // a render array with uc_order_product_view_multiple.
+  // @see https://github.com/backdrop-contrib/ubercart/issues/302  
+  $item = reset($items);
+  $order = uc_order_load($item->order_id);
+  $products = $order->products;
+  $display_items = uc_order_product_view_multiple($products);
   if (!empty($display_items['uc_order_product'])) {
     foreach (element_children($display_items['uc_order_product']) as $key) {
       $display_item = $display_items['uc_order_product'][$key];


### PR DESCRIPTION
Fixes #302

The problem: when a new order is created, `uc_order_product_view_multiple` receives an array of UcCartItems instead of an array of UcOrderProduct. This causes issues when building the renderable array for display and when calculating the total in `theme_uc_cart_review_table`

The solution: although it looks a bit hacky, this is the best I have come up with given the clunky architecture of the order creation on checkout: load the newly created order (which automatically attaches the UcOrderProduct array to it) before sending those products to   `uc_order_product_view_multiple`.  This solves the issue.

EDIT: this solution did not work