### PR TITLE
Issue #324: Check for existence of db table before uninstalling modules.

### DIFF
--- a/uc_file/uc_file.install
+++ b/uc_file/uc_file.install
@@ -258,7 +258,9 @@ function uc_file_update_1000() {
  * Implements hook_uninstall().
  */
 function uc_file_uninstall() {
-  db_delete('uc_product_features')
-    ->condition('fid', 'file')
-    ->execute();
+  if (db_table_exists('uc_product_features')) {
+    db_delete('uc_product_features')
+      ->condition('fid', 'file')
+      ->execute();
+  }
 }

--- a/uc_roles/uc_roles.install
+++ b/uc_roles/uc_roles.install
@@ -242,7 +242,9 @@ function uc_roles_update_1002() {
  * Implements hook_uninstall().
  */
 function uc_roles_uninstall() {
-  db_delete('uc_product_features')
-    ->condition('fid', 'role')
-    ->execute();
+  if (db_table_exists('uc_product_features')) {
+    db_delete('uc_product_features')
+      ->condition('fid', 'role')
+      ->execute();
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/324.