### PR TITLE
Issue 369: Set CC expiration date in uc_credit.test to always be in the future

### DIFF
--- a/payment/uc_credit/tests/uc_credit.test
+++ b/payment/uc_credit/tests/uc_credit.test
@@ -298,7 +298,7 @@ class UbercartCreditCardTestCase extends UbercartTestHelper {
       'panes[payment][details][cc_number]' => array_rand(array_flip(self::$test_cards)),
       'panes[payment][details][cc_cvv]' => mt_rand(100, 999),
       'panes[payment][details][cc_exp_month]' => mt_rand(1, 12),
-      'panes[payment][details][cc_exp_year]' => mt_rand(date('Y') + 1, 2032),
+      'panes[payment][details][cc_exp_year]' => mt_rand(date('Y') + 1, date('Y') + 5),
     ));
     $this->assertText('Your order is complete!');
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/369.