### PR TITLE
Issue #378: “Capitalize addresses” setting not saved in config.

### DIFF
--- a/uc_order/uc_order.module
+++ b/uc_order/uc_order.module
@@ -640,6 +640,7 @@ function uc_order_form_uc_store_settings_form_alter(&$form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Capitalize address on order screens'),
     '#default_value' => config_get('uc_order.settings', 'uc_order_capitalize_addresses'),
+    '#config' => 'uc_order.settings',
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/378.