### PR TITLE
Issue #407: Eliminate “deprecated conversion” notice in PHP 8.1.

### DIFF
--- a/uc_cart/uc_cart.module
+++ b/uc_cart/uc_cart.module
@@ -320,7 +320,7 @@ function uc_cart_block_view($delta = '', $settings = array(), $contexts = array(
         $help_text = check_plain($text);
       }
 
-      $items = FALSE;
+      $items = array();
       $item_count = 0;
       $total = 0;
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/407.