### PR TITLE
Issue #396: Remove deprecated node_types_rebuild() calls.

### DIFF
--- a/uc_product/uc_product.admin.inc
+++ b/uc_product/uc_product.admin.inc
@@ -458,7 +458,6 @@ function uc_product_class_form_submit($form, &$form_state) {
     module_invoke_all('uc_product_class', $pcid, 'update');
   }
 
-  node_types_rebuild();
   if ($is_new) {
     $type = node_type_get_type($pcid);
     node_add_body_field($type, t('Description'));
@@ -511,7 +510,6 @@ function uc_product_class_delete_confirm_submit($form, &$form_state) {
   module_invoke_all('uc_product_class', $form_state['values']['pcid'], 'delete');
   // TODO migrate This needed?
   uc_product_node_info(TRUE);
-  node_types_rebuild();
   menu_rebuild();
 
   backdrop_set_message(t('Product class %type deleted.', array('%type' => $form_state['values']['pcid'])));

--- a/uc_product/uc_product.admin.inc
+++ b/uc_product/uc_product.admin.inc
@@ -458,6 +458,7 @@ function uc_product_class_form_submit($form, &$form_state) {
     module_invoke_all('uc_product_class', $pcid, 'update');
   }
 
+  node_type_cache_reset();
   if ($is_new) {
     $type = node_type_get_type($pcid);
     node_add_body_field($type, t('Description'));
@@ -510,6 +511,7 @@ function uc_product_class_delete_confirm_submit($form, &$form_state) {
   module_invoke_all('uc_product_class', $form_state['values']['pcid'], 'delete');
   // TODO migrate This needed?
   uc_product_node_info(TRUE);
+  node_type_cache_reset();
   menu_rebuild();
 
   backdrop_set_message(t('Product class %type deleted.', array('%type' => $form_state['values']['pcid'])));

--- a/uc_product/uc_product.features.inc
+++ b/uc_product/uc_product.features.inc
@@ -88,7 +88,6 @@ function uc_product_classes_features_revert($module) {
     }
     // TODO migrate this
     uc_product_node_info(TRUE);
-    node_types_rebuild();
     menu_rebuild();
   }
 }

--- a/uc_product/uc_product.features.inc
+++ b/uc_product/uc_product.features.inc
@@ -88,6 +88,7 @@ function uc_product_classes_features_revert($module) {
     }
     // TODO migrate this
     uc_product_node_info(TRUE);
+    node_type_cache_reset();
     menu_rebuild();
   }
 }

--- a/uc_product/uc_product.install
+++ b/uc_product/uc_product.install
@@ -230,7 +230,6 @@ function uc_product_disable() {
 function uc_product_enable() {
   $body_label = t('Description');
 
-  node_types_rebuild();
   $types = node_type_get_types();
   foreach ($types as $type) {
     if ($type->module == 'uc_product') {

--- a/uc_product/uc_product.install
+++ b/uc_product/uc_product.install
@@ -237,9 +237,8 @@ function uc_product_enable() {
       uc_product_set_teaser_display($type->type);
     }
   }
-  node_type_cache_reset();
-
   uc_product_add_default_image_field();
+  node_type_cache_reset();
 
   // Make sure 'uc_products' view gets enabled.
   $config = config('views.view.uc_products');

--- a/uc_product/uc_product.install
+++ b/uc_product/uc_product.install
@@ -237,6 +237,7 @@ function uc_product_enable() {
       uc_product_set_teaser_display($type->type);
     }
   }
+  node_type_cache_reset();
 
   uc_product_add_default_image_field();
 

--- a/uc_product_kit/uc_product_kit.install
+++ b/uc_product_kit/uc_product_kit.install
@@ -101,6 +101,7 @@ function uc_product_kit_enable() {
   }
 
   // Add the body field.
+  node_type_cache_reset();
   $types = node_type_get_types();
   node_add_body_field($types['product_kit'], t('Description'));
 

--- a/uc_product_kit/uc_product_kit.install
+++ b/uc_product_kit/uc_product_kit.install
@@ -101,7 +101,6 @@ function uc_product_kit_enable() {
   }
 
   // Add the body field.
-  node_types_rebuild();
   $types = node_type_get_types();
   node_add_body_field($types['product_kit'], t('Description'));
 

--- a/uc_taxes/tests/uc_taxes.test
+++ b/uc_taxes/tests/uc_taxes.test
@@ -298,7 +298,6 @@ class UbercartTaxesTestCase extends UbercartTestHelper {
       'description' => $this->randomName(32),
     );
     $this->backdropPost('admin/store/products/classes', $edit, t('Save'));
-    node_types_rebuild();
 
     // Create a tax rate.
     $tax = $this->randomName(8);

--- a/uc_taxes/tests/uc_taxes.test
+++ b/uc_taxes/tests/uc_taxes.test
@@ -298,6 +298,7 @@ class UbercartTaxesTestCase extends UbercartTestHelper {
       'description' => $this->randomName(32),
     );
     $this->backdropPost('admin/store/products/classes', $edit, t('Save'));
+    node_type_cache_reset();
 
     // Create a tax rate.
     $tax = $this->randomName(8);


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/396.