### PR TITLE
Issue #341: Replace “My order history” with “username: order history”

### DIFF
--- a/uc_order/config/views.view.uc_orders_user.json
+++ b/uc_order/config/views.view.uc_orders_user.json
@@ -19,7 +19,7 @@
                         "query_comment": false
                     }
                 },
-                "title": "My order history",
+                "title": "%1: order history",
                 "access": {
                     "type": "perm",
                     "perm": "view own orders"

--- a/uc_order/tests/uc_order.test
+++ b/uc_order/tests/uc_order.test
@@ -131,7 +131,7 @@ class UbercartOrderTestCase extends UbercartTestHelper {
 
     $this->backdropLogin($this->customer);
     $this->backdropGet('user/' . $this->customer->uid . '/orders');
-    $this->assertText(t('My order history'));
+    $this->assertText(t('@name: order history', array('@name' => $this->customer->name)));
 
     $this->backdropGet('user/' . $this->customer->uid . '/orders/' . $order->order_id);
     $this->assertResponse(200, 'Customer can view their own order.');

--- a/uc_order/uc_order.admin.inc
+++ b/uc_order/uc_order.admin.inc
@@ -880,11 +880,11 @@ function uc_order_select_customer_form($form, &$form_state, $options = NULL) {
  *
  * This function is deprecated; this listing is now provided by Views.
  *
- * @param $uid
- *   The user ID whose orders you wish to list.
+ * @param $account
+ *   The user whose orders you wish to list.
  */
-function uc_order_history($user) {
-  backdrop_set_title(t('My order history'));
+function uc_order_history($account) {
+  backdrop_set_title(t('@name: order history', array('@name' => $account->name)));
 
   $header = array(
     array(
@@ -919,7 +919,7 @@ function uc_order_history($user) {
   $o_total = $query->addField('o', 'order_total');
   $o_uid = $query->addField('o', 'uid');
 
-  $query->condition($o_uid, $user->uid)
+  $query->condition($o_uid, $account->uid)
     ->condition($o_status, uc_order_status_list('general', TRUE), 'IN');
 
   $count_query = $query->countQuery();
@@ -945,7 +945,7 @@ function uc_order_history($user) {
 
   // Build a table based on the customer's orders.
   foreach ($result as $order) {
-    $link = l($order->order_id, 'user/' . $user->uid . '/orders/' . $order->order_id);
+    $link = l($order->order_id, 'user/' . $account->uid . '/orders/' . $order->order_id);
 
     if (user_access('view all orders')) {
       $link .= '<span class="order-admin-icons">' . uc_order_actions($order, TRUE) . '</span>';


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/341.

Also corrects the documentation of function `uc_order_history()` (even though it's deprecated). It was wrong in D7, too (where it wasn't deprecated).