### PR TITLE
Issue #485: Fix implicit float-to-int conversion deprecation warning.

### DIFF
--- a/uc_store/classes/encrypt.inc
+++ b/uc_store/classes/encrypt.inc
@@ -205,7 +205,7 @@ class UbercartEncryption {
     $fudgefactor[] = $fudge;
 
     if (!empty($this->mod)) {
-      if ($fudge % $this->mod == 0) {
+      if (((int) $fudge) % $this->mod == 0) {
         $fudge = $fudge * -1;
       }
     }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/485.