### PR TITLE
Issue #499: Use core icon for Store menu in admin bar.

### DIFF
--- a/uc_cart/tests/uc_cart.test
+++ b/uc_cart/tests/uc_cart.test
@@ -289,7 +289,7 @@ class UbercartCartCheckoutTestCase extends UbercartTestHelper {
     // Test new account email.
     $mail = $this->backdropGetMails(array('id' => 'user_register_no_approval_required'));
     $mail = array_pop($mail);
-    $new_user = new stdClass();
+    $new_user = new User();
     $new_user->name = $mail['params']['account']->name;
     $new_user->pass_raw = $mail['params']['account']->password;
     $this->assertTrue(!empty($new_user->name), 'New username is not empty.');

--- a/uc_cart/tests/uc_cart.test
+++ b/uc_cart/tests/uc_cart.test
@@ -240,7 +240,7 @@ class UbercartCartCheckoutTestCase extends UbercartTestHelper {
     $this->backdropPost('admin/store/settings/checkout', $settings, t('Save configuration'));
     $this->backdropLogout();
 
-    $new_user = new stdClass();
+    $new_user = new User();
     $new_user->name = $this->randomName(20);
     $new_user->pass_raw = $this->randomName(20);
 

--- a/uc_store/uc_store.css
+++ b/uc_store/uc_store.css
@@ -73,14 +73,6 @@
 }
 
 /**
-  * Icon for main level nav to match core.
-  */
-#admin-bar #admin-bar-menu > li > .dropdown > li > a.admin-store {
-  background: transparent url(images/cart--white--64.png) 5% center no-repeat;
-  background-size: 16px;
-}
-
-/**
  * Icon support for admin (http://drupal.org/project/admin).
  */
 .path-admin-store-orders span.icon {

--- a/uc_store/uc_store.module
+++ b/uc_store/uc_store.module
@@ -292,6 +292,7 @@ function uc_store_init() {
   if ($parts[1] < 28) {
     // For Backdrop versions below 1.28.0, use a CSS icon for the Store menu in
     // the admin bar. 1.28.0 and higher will use a core icon.
+    global $base_url;
     $path = $base_url . '/' . backdrop_get_path('module', 'uc_store');
     backdrop_add_css('
 #admin-bar #admin-bar-menu > li > .dropdown > li > a.admin-store {

--- a/uc_store/uc_store.module
+++ b/uc_store/uc_store.module
@@ -165,6 +165,7 @@ function uc_store_menu() {
     'page callback' => 'uc_store_admin',
     'access callback' => 'uc_store_admin_access',
     'weight' => -12,
+    'icon' => 'shopping-cart-simple-fill',
     'file' => 'uc_store.admin.inc',
   );
   $items['admin/store/reports'] = array(
@@ -286,6 +287,18 @@ function uc_store_admin_access() {
  */
 function uc_store_init() {
   module_load_include('inc', 'uc_store', 'includes/tapir');
+
+  $parts = explode('.', BACKDROP_VERSION);
+  if ($parts[1] < 28) {
+    // For Backdrop versions below 1.28.0, use a CSS icon for the Store menu in
+    // the admin bar. 1.28.0 and higher will use a core icon.
+    $path = $base_url . '/' . backdrop_get_path('module', 'uc_store');
+    backdrop_add_css('
+#admin-bar #admin-bar-menu > li > .dropdown > li > a.admin-store {
+  background: transparent url(' . $path . '/images/cart--white--64.png) 5% center no-repeat;
+  background-size: 16px;
+}', 'inline');
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/499.