### PR TITLE
Issue 554: Check for empty quantity when validating user roles.

### DIFF
--- a/uc_roles/uc_roles.module
+++ b/uc_roles/uc_roles.module
@@ -258,7 +258,7 @@ function uc_roles_user_validate($form, &$form_state) {
     foreach ((array) $edit['table'] as $role => $value) {
       // We don't validate if nothing was actually selected, the role, or the
       // expiration is removed.
-      if ($value['qty'] == 0 || $value['remove'] == 1 || !$edit['roles'][$role]) {
+      if (empty($value['qty']) || $value['qty'] == 0 || $value['remove'] == 1 || !$edit['roles'][$role]) {
         continue;
       }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/554.