### PR TITLE
Issue #589: Fix escaped backtick in update warning.

### DIFF
--- a/payment/uc_paypal/uc_paypal.install
+++ b/payment/uc_paypal/uc_paypal.install
@@ -215,7 +215,7 @@ function uc_paypal_update_1002() {
  */
 function uc_paypal_update_1003() {
   $t = get_t();
-  backdrop_set_message($t('PayPal Website Payments Standard, PayPal Payments Pro and PayPal Express Checkout provided by Ubercart\'s uc_paypal submodule are deprecated and will stop working in 2027. Please enable and switch to the PayPal Checkout (uc_paypal_checkout) submodule for a modern payment solution that makes use of PayPal\`s REST API.'), 'warning');
+  backdrop_set_message($t('PayPal Website Payments Standard, PayPal Payments Pro and PayPal Express Checkout provided by Ubercart\'s uc_paypal submodule are deprecated and will stop working in 2027. Please enable and switch to the PayPal Checkout (uc_paypal_checkout) submodule for a modern payment solution that makes use of PayPal\'s REST API.'), 'warning');
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ubercart/issues/589.